### PR TITLE
Fix nesting issue that caused a crash when accessing a device through SSH

### DIFF
--- a/lib/lib/device.rb
+++ b/lib/lib/device.rb
@@ -59,28 +59,25 @@ module Idb
         $log.debug "opening tool port #{@tool_port} for internal ssh connection"
         @usbmuxd.proxy @tool_port, $settings['ssh_port']
 
+      end
 
+      @apps_dir_ios_pre8 = '/private/var/mobile/Applications'
+      @apps_dir_ios_8 = '/private/var/mobile/Containers/Bundle/Application'
+      @data_dir_ios_8 = '/private/var/mobile/Containers/Data/Application'
 
-        @apps_dir_ios_pre8 = '/private/var/mobile/Applications'
-        @apps_dir_ios_8 = '/private/var/mobile/Containers/Bundle/Application'
-        @data_dir_ios_8 = '/private/var/mobile/Containers/Data/Application'
+      if @ops.directory? @apps_dir_ios_pre8
+        @ios_version = 7 # 7 or earlier
+        @apps_dir = @apps_dir_ios_pre8
+        @data_dir = @apps_dir_ios_pre8
 
-        if @ops.directory? @apps_dir_ios_pre8
-          @ios_version = 7 # 7 or earlier
-          @apps_dir = @apps_dir_ios_pre8
-          @data_dir = @apps_dir_ios_pre8
+      elsif @ops.directory? @apps_dir_ios_8
+        @ios_version = 8
+        @apps_dir = @apps_dir_ios_8
+        @data_dir = @data_dir_ios_8
 
-        elsif @ops.directory? @apps_dir_ios_8
-          @ios_version = 8
-          @apps_dir = @apps_dir_ios_8
-          @data_dir = @data_dir_ios_8
-
-        else
-          $log.error "Unsupported iOS Version."
-          raise
-        end
-
-
+      else
+        $log.error "Unsupported iOS Version."
+        raise
       end
 
       start_port_forwarding


### PR DESCRIPTION
The code determining the proper @apps_dir variable for a device was accidentally nested only inside the branch that uses usbmuxd. When connected to a device over SSH, @apps_dir was nil and clicking "Select App" would cause a crash.
