### PR TITLE
Reordered Apps Dir Checking

### DIFF
--- a/lib/lib/device.rb
+++ b/lib/lib/device.rb
@@ -58,29 +58,25 @@ module Idb
         @tool_port = @usbmuxd.find_available_port
         $log.debug "opening tool port #{@tool_port} for internal ssh connection"
         @usbmuxd.proxy @tool_port, $settings['ssh_port']
+     end
 
+      @apps_dir_ios_pre8 = '/private/var/mobile/Applications'
+      @apps_dir_ios_8 = '/private/var/mobile/Containers/Bundle/Application'
+      @data_dir_ios_8 = '/private/var/mobile/Containers/Data/Application'
 
+      if @ops.directory? @apps_dir_ios_8
+        @ios_version = 8
+        @apps_dir = @apps_dir_ios_8
+        @data_dir = @data_dir_ios_8
 
-        @apps_dir_ios_pre8 = '/private/var/mobile/Applications'
-        @apps_dir_ios_8 = '/private/var/mobile/Containers/Bundle/Application'
-        @data_dir_ios_8 = '/private/var/mobile/Containers/Data/Application'
+      elsif @ops.directory? @apps_dir_ios_pre8
+        @ios_version = 7 # 7 or earlier
+        @apps_dir = @apps_dir_ios_pre8
+        @data_dir = @apps_dir_ios_pre8
 
-        if @ops.directory? @apps_dir_ios_pre8
-          @ios_version = 7 # 7 or earlier
-          @apps_dir = @apps_dir_ios_pre8
-          @data_dir = @apps_dir_ios_pre8
-
-        elsif @ops.directory? @apps_dir_ios_8
-          @ios_version = 8
-          @apps_dir = @apps_dir_ios_8
-          @data_dir = @data_dir_ios_8
-
-        else
-          $log.error "Unsupported iOS Version."
-          raise
-        end
-
-
+      else
+        $log.error "Unsupported iOS Version."
+        raise
       end
 
       start_port_forwarding


### PR DESCRIPTION
The checks for the apps directory for a device was crashing idb 
when working with iOS 8 devices (iPad Air 2 LTE), because the 
directory '/private/var/mobile/Applications' existed (but was empty).
This caused idb to set the '@ios_version' to 7.  I changed it
to check for the iOS 8 dirs first, which will definitely not
exist on iOS 7 devices.  This fix also incorporates the pull-request
for SSH connection issues.  Tested on iPhone 4 (iOS 7.1.2), iPad
Air 2 (iOS 8.1)
