### PR TITLE
Fix Disconnect Crash with SSH

### DIFF
--- a/lib/lib/device.rb
+++ b/lib/lib/device.rb
@@ -334,7 +334,10 @@ module Idb
       $log.info "Terminating port forwarding helper..."
       Process.kill("INT", @port_forward_pid)
       $log.info "Stopping any SSH via USB forwarding"
-      @usbmuxd.stop_all
+
+      if $settings['device_connection_mode'] != "ssh"
+        @usbmuxd.stop_all
+      end
     end
 
     def open_url url


### PR DESCRIPTION
idb crashes when you select "Disconnect" while using SSH, because
idb tries stop usbmuxd port forwarding, but the object is Nil.
