### PR TITLE
Check for nil before attempting to open_url

### DIFF
--- a/lib/gui/url_scheme_fuzz_widget.rb
+++ b/lib/gui/url_scheme_fuzz_widget.rb
@@ -62,6 +62,10 @@ module Idb
         }
         input = @fuzzer.generate_inputs @fuzz_config_template.text, fuzz_strings
         input.each { |url|
+          if url.nil?
+            $log.warn "Skipping nil URL"
+            next
+          end
           #TODO: progress bar
           #TODO: kill app after each run
           #TODO: check for crash report


### PR DESCRIPTION
If a user enters an invalid URL in the fuzzing pane, an array with
nil entries is returned. Each of these nil entries should be
skipped.
