### PR TITLE
Clutch support (along with iOS 9.3.3 changes)

### DIFF
--- a/lib/gui/app_list_dialog.rb
+++ b/lib/gui/app_list_dialog.rb
@@ -44,7 +44,7 @@ module Idb
     end
 
     def refresh_app_list
-      if $device.ios_version == 8
+      if $device.ios_version >= 8
         box = Qt::MessageBox.new 1, "Refreshing...", "Refreshing uicache to ensure app information is up-to-date. This may take a few seconds."
         box.setStandardButtons(0)
         box.show

--- a/lib/gui/device_status_dialog.rb
+++ b/lib/gui/device_status_dialog.rb
@@ -17,7 +17,7 @@ module Idb
 
     def mark_clutch_installed
       @clutch_label.text = @clutch_label.text + "<br>found: #{$device.clutch_path}"
-      @layout.addWidget installed_check_mark, 8, 1
+      @layout.addWidget installed_check_mark, 9, 1
       setFixedHeight(sizeHint().height());
     end
 
@@ -275,6 +275,31 @@ module Idb
       end
     end
 
+    def clutch_section
+      @clutch_label = Qt::Label.new "<b>Clutch</b><br>(Decrypt app binaries on the device).<br>Developed and maintained by KJCracks https://github.com/KJCracks/Clutch"
+      @layout.addWidget @clutch_label, 9, 0
+
+      if $device.clutch_installed?
+        mark_clutch_installed
+      else
+        @install_clutch = Qt::PushButton.new "Install"
+        @install_clutch.connect(SIGNAL(:released)) {
+          $device.setup_clutch_sources
+          $device.install_clutch
+          if $device.clutch_installed?
+            @install_clutch.hide
+            mark_clutch_installed
+          else
+            error = Qt::MessageBox.new
+            error.setInformativeText("clutch could not be installed. Please make sure Cydia has finished all tasks and is closed on the device.")
+            error.setIcon(Qt::MessageBox::Critical)
+            error.exec
+          end
+        }
+        @layout.addWidget @install_clutch, 9, 1
+      end
+    end
+
 
     def initialize *args
       super *args
@@ -287,7 +312,7 @@ module Idb
         reject()
       }
       #TODO: prevent closing
-      @layout.addWidget @close_button, 9, 2
+      @layout.addWidget @close_button, 10, 2
 
       apt_get_section
       open_section
@@ -298,6 +323,7 @@ module Idb
       keychaineditor_section
       rsync_section
       cycript_section
+      clutch_section
 
 
       setFixedHeight(sizeHint().height());

--- a/lib/gui/fs_viewer_tab_widget.rb
+++ b/lib/gui/fs_viewer_tab_widget.rb
@@ -53,7 +53,7 @@ module Idb
       @layout.addWidget @rsync, 0,4
       @rsync.connect(SIGNAL :released) {
         @manager.start_new_revision
-        if $device.ios_version == 8
+        if $device.ios_version >= 8
           @manager.sync_dir $selected_app.app_dir, "app_bundle"
           @manager.sync_dir $selected_app.data_dir, "data_bundle"
         else
@@ -328,7 +328,7 @@ module Idb
 
       @controls.update_start
 
-      if $device.ios_version == 8
+      if $device.ios_version >= 8
         start_ios_8
       else
         start_ios_pre8

--- a/lib/lib/app.rb
+++ b/lib/lib/app.rb
@@ -16,15 +16,18 @@ module Idb
       @app_dir = "#{$device.apps_dir}/#{@uuid}"
       parse_info_plist
 
-      if $device.ios_version == 8
-        mapping_file = "/var/mobile/Library/MobileInstallation/LastLaunchServicesMap.plist"
+      if $device.ios_version >= 8
+        if $device.ios_version == 8
+          mapping_file = "/var/mobile/Library/MobileInstallation/LastLaunchServicesMap.plist"
+        else
+          mapping_file = "/private/var/installd/Library/MobileInstallation/LastLaunchServicesMap.plist"
+        end
         local_mapping_file =  cache_file mapping_file
         @services_map = IOS8LastLaunchServicesMapWrapper.new local_mapping_file
-
         @data_dir = @services_map.data_path_by_bundle_id @info_plist.bundle_identifier
         @keychain_access_groups = @services_map.keychain_access_groups_by_bundle_id @info_plist.bundle_identifier
 
-       else
+      else
         @data_dir = @app_dir
       end
 
@@ -164,8 +167,8 @@ module Idb
     end
 
     def data_directory
-      if $device.ios_version != 8
-        "[iOS 8 specific]"
+      if $device.ios_version < 8
+        "[iOS 8+ specific]"
       else
         @data_dir
       end

--- a/lib/lib/device.rb
+++ b/lib/lib/device.rb
@@ -31,7 +31,7 @@ module Idb
       @device_app_paths[:pbwatcher] = ["/var/root/pbwatcher"]
       @device_app_paths[:dumpdecrypted_armv7] = ["/var/root/dumpdecrypted_armv7.dylib"]
       @device_app_paths[:dumpdecrypted_armv6] = ["/var/root/dumpdecrypted_armv6.dylib"]
-      @device_app_paths[:clutch] = ["/usr/bin/Clutch"]
+      @device_app_paths[:clutch] = ["/var/root/Clutch"]
 
       if $settings['device_connection_mode'] == "ssh"
         $log.debug "Connecting via SSH"
@@ -294,7 +294,7 @@ module Idb
     end
 
     def setup_clutch_sources
-      @ops.execute("echo “deb http://cydia.iphonecake.com ./“ > /etc/apt/sources.list.d/idb_clutch.list")
+      @ops.execute("echo \"deb http://cydia.iphonecake.com ./\" > /etc/apt/sources.list.d/idb_clutch.list")
     end
 
     def install_from_cydia package
@@ -302,7 +302,8 @@ module Idb
         $log.info "Updating package repo..."
         @ops.execute("#{apt_get_path} -y update")
         $log.info "Installing #{package}..."
-        @ops.execute("#{apt_get_path} -y install #{package}")
+        # TODO: is force-yes secure? It is needed cuz clutch repo is unauthenticated
+        @ops.execute("#{apt_get_path} -y --force-yes install #{package}")
         return true
       else
         $log.error "apt-get or aptitude not found on the device"
@@ -315,7 +316,10 @@ module Idb
     end
 
     def install_clutch
-      install_from_cydia "com.iphonecake.clutch"
+      install_from_cydia "com.iphonecake.clutch2"
+      # NOTE: For some reason this binary will fail if run from default /usr/bin partition on iOS 9.3.3
+      # Must be copied to root home directory
+      @ops.execute("cp /usr/bin/Clutch2 /var/root/Clutch")
     end
 
     def install_rsync
@@ -357,7 +361,7 @@ module Idb
     end
 
     def configured?
-      apt_get_installed? and open_installed? and openurl_installed? and dumpdecrypted_installed? and pbwatcher_installed? and pcviewer_installed? and keychain_editor_installed? and rsync_installed? and cycript_installed?
+      apt_get_installed? and open_installed? and openurl_installed? and dumpdecrypted_installed? and pbwatcher_installed? and pcviewer_installed? and keychain_editor_installed? and rsync_installed? and cycript_installed? and clutch_installed?
     end
 
 

--- a/lib/lib/device.rb
+++ b/lib/lib/device.rb
@@ -66,8 +66,15 @@ module Idb
       @apps_dir_ios_8 = '/private/var/mobile/Containers/Bundle/Application'
       @data_dir_ios_8 = '/private/var/mobile/Containers/Data/Application'
 
+      @apps_dir_ios_9 = '/private/var/containers/Bundle/Application'
+      @data_dir_ios_9 = @data_dir_ios_8
 
-      if @ops.directory? @apps_dir_ios_8
+      if @ops.directory? @apps_dir_ios_9
+        @ios_version = 9
+        @apps_dir = @apps_dir_ios_9
+        @data_dir = @data_dir_ios_9
+
+      elsif @ops.directory? @apps_dir_ios_8
         @ios_version = 8
         @apps_dir = @apps_dir_ios_8
         @data_dir = @data_dir_ios_8


### PR DESCRIPTION
Added support for using Clutch instead of dumpdecrypted since it does not work in iOS 9.3.3.  Mostly expanded upon existing skeleton code for handling Clutch.