### PR TITLE
Fixed SSH Connection Bug

### DIFF
--- a/lib/idb.rb
+++ b/lib/idb.rb
@@ -204,8 +204,8 @@ module Idb
                                  $settings.ssh_password,
                                  $settings.ssh_host,
                                  $settings.ssh_port
-          rescue
-
+          rescue StandardError => ex
+            $log.error ex
           end
           unless $device.nil?
             unless $device.configured?

--- a/lib/lib/device.rb
+++ b/lib/lib/device.rb
@@ -45,7 +45,7 @@ module Idb
 
         @usbmuxd.proxy proxy_port, $settings['ssh_port']
         sleep 1
-
+        
         @ops = SSHOperations.new username, password, 'localhost', proxy_port
 
         @usb_ssh_port = $settings['manual_ssh_port']

--- a/lib/lib/ssh_operations.rb
+++ b/lib/lib/ssh_operations.rb
@@ -12,11 +12,11 @@ module Idb
       @password = password
       @port = port
       $log.info "Establishing SSH Session for #{username}@#{hostname}:#{port}"
-      connnect
+      connect
     end
 
     def connect
-      @ssh = Net::SSH.start hostname, username, password: password, port: port
+      @ssh = Net::SSH.start @hostname, @username, password: @password, port: @port
 
       # initialize sftp connection and wait until it is open
       $log.info 'Establishing SFTP Session...'


### PR DESCRIPTION
The `connect` method was misspelled (3 n's). Also when moving the code
from the `initialize` method to `connect` the variables weren't switched
to use the instance variable versions.

Finally, none of this was being ouput because of some weird unexpected
behavior in nested exception handling code. The outermost begin rescue
in `lib/idb.rb` silently caught exceptions. This is somehow effecting
the exception handling code that was in `lib/lib/ssh_operations.rb`.